### PR TITLE
expose size, color and opacity of legend scatter plot

### DIFF
--- a/R/tricolore.R
+++ b/R/tricolore.R
@@ -899,6 +899,9 @@ ColorKeySextant <- function (center, values, label_as, show_center,
 #'   (default='pct' if center is at c(1/3, 1/3, 1/3), otherwise 'pct_diff')
 #' @param crop Should the legend be cropped to the data? (default=FALSE)
 #' @param input_validation Should the function arguments be validated? (default=TRUE)
+#' @param data_size Size of data point in legend (default=0.5)
+#' @param data_alpha Opacity of data point in legend (default=0.5)
+#' @param data_color Color of data point in legend (default='black')
 #'
 #' @return
 #' * legend=FALSE: A vector of rgbs hex-codes representing the ternary balance
@@ -924,7 +927,7 @@ Tricolore <- function (df, p1, p2, p3,
                                             FALSE, TRUE),
                        label_as = ifelse(identical(center, rep(1/3, 3)),
                                          'pct', 'pct_diff'),
-                       crop = FALSE, input_validation = TRUE) {
+                       crop = FALSE, input_validation = TRUE,data_size=0.5,data_alpha=0.5,data_color="black") {
 
   # validation of main input arguments
   if (input_validation) {
@@ -972,7 +975,7 @@ Tricolore <- function (df, p1, p2, p3,
         labs(x = p1, y = p2, z = p3),
         if (show_data) {
           geom_point(aes_string(x = 'p1', y = 'p2', z = 'p3'),
-                     color = 'black', shape = 16, size = 0.5, alpha = 0.5,
+                     color = data_color, shape = 16, size = data_size, alpha = data_alpha,
                      data = mixture)
         }
       )

--- a/man/Tricolore.Rd
+++ b/man/Tricolore.Rd
@@ -10,7 +10,8 @@ Tricolore(df, p1, p2, p3, center = rep(1/3, 3),
   legend = TRUE, show_data = TRUE,
   show_center = ifelse(identical(center, rep(1/3, 3)), FALSE, TRUE),
   label_as = ifelse(identical(center, rep(1/3, 3)), "pct", "pct_diff"),
-  crop = FALSE, input_validation = TRUE)
+  crop = FALSE, input_validation = TRUE, data_size = 0.5,
+  data_alpha = 0.5, data_color = "black")
 }
 \arguments{
 \item{df}{Data frame of compositional data.}
@@ -56,6 +57,12 @@ percent-point-difference from center labels.
 \item{crop}{Should the legend be cropped to the data? (default=FALSE)}
 
 \item{input_validation}{Should the function arguments be validated? (default=TRUE)}
+
+\item{data_size}{Size of data point in legend (default=0.5)}
+
+\item{data_alpha}{Opacity of data point in legend (default=0.5)}
+
+\item{data_color}{Color of data point in legend (default='black')}
 }
 \value{
 \itemize{


### PR DESCRIPTION
Expose the dot colour, size and opacity in the legend plot for fine-tuning. Especially useful when the legend plot becomes the main focus like [in this example](https://doodles.mountainmath.ca/blog/2018/10/13/council-candidate-neighbourhoods/).